### PR TITLE
feat: using a recursive lock for the entire scope of the start methods MOVEMENT-1572

### DIFF
--- a/mbf_abstract_nav/src/controller_action.cpp
+++ b/mbf_abstract_nav/src/controller_action.cpp
@@ -55,6 +55,7 @@ void ControllerAction::start(
     typename AbstractControllerExecution::Ptr execution_ptr
 )
 {
+  boost::lock_guard<boost::recursive_mutex> guard(slot_map_mtx_);
   if(goal_handle.getGoalStatus().status == actionlib_msgs::GoalStatus::RECALLING)
   {
     goal_handle.setCanceled();
@@ -64,7 +65,6 @@ void ControllerAction::start(
   uint8_t slot = goal_handle.getGoal()->concurrency_slot;
 
   bool update_plan = false;
-  slot_map_mtx_.lock();
   std::map<uint8_t, ConcurrencySlot>::iterator slot_it = concurrency_slots_.find(slot);
   if(slot_it != concurrency_slots_.end())
   {
@@ -84,7 +84,6 @@ void ControllerAction::start(
       concurrency_slots_[slot].goal_handle.setAccepted();
     }
   }
-  slot_map_mtx_.unlock();
   if(!update_plan)
   {
       // Otherwise run parent version of this method


### PR DESCRIPTION
the act of locking and unlocking for the duration of these start methods allow for 2 threads simultaneously accessing this code to start a thread, and then immediately overwrite the memory referencing the thread without cleaning up the leaked thread.